### PR TITLE
Handle "unimplemented" roles. Fixes #1610287.

### DIFF
--- a/doc8/checks.py
+++ b/doc8/checks.py
@@ -102,6 +102,7 @@ class CheckValidity(ContentCheck):
         re.compile(r'^Unknown directive type'),
         re.compile(r'^Undefined substitution'),
         re.compile(r'^Substitution definition contains illegal element'),
+        re.compile(r'^Interpreted text role ".*" not implemented'),
     ]
 
     def __init__(self, cfg):


### PR DESCRIPTION
The unimplemented (but defined) roles are:
- index (implemented by Sphinx)
- named-reference
- anonymous-reference
- uri-reference
- footnote-reference
- citation-reference
- substitution-reference
- target
- restructuredtext-unimplemented-role